### PR TITLE
Update dependencies to recent version

### DIFF
--- a/coc.coffee
+++ b/coc.coffee
@@ -3,7 +3,7 @@ module.exports = (env) ->
 
   Promise   = env.require 'bluebird'
   serialport = require 'serialport'
-  SerialPort = serialport.SerialPort
+  SerialPort = require 'serialport'
 
   Gpio = env.Gpio or require('onoff').Gpio
   Promise.promisifyAll(Gpio.prototype)
@@ -89,7 +89,7 @@ module.exports = (env) ->
     constructor: (serialPortName, baudrate, @receiveCommandHandler) ->
 
       @cmdString = ""
-      @serial = new SerialPort serialPortName, baudrate: baudrate, false
+      @serial = new SerialPort serialPortName, baudRate: baudrate, false
 
       @serial.open (err) ->
         if ( err? )

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   "private": false,
   "configSchema": "coc-plugin-config-schema.coffee",
   "dependencies": {
-    "onoff": "~1.1.1",
-    "serialport": "~2.0.6"
+    "onoff": "~3.1.0",
+    "serialport": "~6.2.1"
   },
   "peerDependencies": {
     "pimatic": "0.9.*"


### PR DESCRIPTION
Serialport 2.0.6 doesn't compile any more with recent versions of gcc. However with minimal changes the plugin works with the latest version of serialport (currently 6.2.1) as well.